### PR TITLE
Determining the content type and length in a fast way without using any dependency

### DIFF
--- a/contentManagement/pom.xml
+++ b/contentManagement/pom.xml
@@ -39,10 +39,5 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-core</artifactId>
-            <version>2.7.0</version>
-        </dependency>
     </dependencies>
 </project>

--- a/contentManagement/src/main/java/com/audiophileproject/main/controllers/ContentController.java
+++ b/contentManagement/src/main/java/com/audiophileproject/main/controllers/ContentController.java
@@ -29,7 +29,7 @@ public class ContentController {
 		var content = Content.builder()
 				.title(request.getTitle())
 				.url(request.getUrl())
-				.type(request.getType())
+				.contentType(request.getContentType())
 				.length(request.getLength())
 				.pubDate(request.getPubDate())
 				.description(request.getDescription())

--- a/contentManagement/src/main/java/com/audiophileproject/main/dto/ContentRequest.java
+++ b/contentManagement/src/main/java/com/audiophileproject/main/dto/ContentRequest.java
@@ -1,10 +1,12 @@
 package com.audiophileproject.main.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.net.URL;
 import java.util.Date;
 import java.util.List;
 
@@ -14,9 +16,10 @@ import java.util.List;
 public class ContentRequest {
 	@NotBlank(message = "the title is required")
 	private String title;
-	@NotBlank(message = "the url is required")
-	private String url;
-	private String type;
+	@NotNull(message = "the url is required")
+	private URL url;
+	// TODO: validate the contentType
+	private String contentType;
 	private Long length;
 	private Date pubDate;
 	private String description;

--- a/contentManagement/src/main/java/com/audiophileproject/main/dto/ContentResponse.java
+++ b/contentManagement/src/main/java/com/audiophileproject/main/dto/ContentResponse.java
@@ -3,6 +3,7 @@ package com.audiophileproject.main.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
+import java.net.URL;
 import java.util.Date;
 import java.util.List;
 
@@ -11,8 +12,8 @@ import java.util.List;
 public record ContentResponse (
 	 long id,
 	 String title,
-	 String url,
-	 String type,
+	 URL url,
+	 String contentType,
 	 Long length,
 	 Date pubDate,
 	 String description,

--- a/contentManagement/src/main/java/com/audiophileproject/main/dto/ContentResponseMapper.java
+++ b/contentManagement/src/main/java/com/audiophileproject/main/dto/ContentResponseMapper.java
@@ -13,7 +13,7 @@ public class ContentResponseMapper implements Function<Content, ContentResponse>
                 .id(content.getId())
                 .title(content.getTitle())
                 .url(content.getUrl())
-                .type(content.getType())
+                .contentType(content.getContentType())
                 .length(content.getLength())
                 .pubDate(content.getPubDate())
                 .description(content.getDescription())

--- a/contentManagement/src/main/java/com/audiophileproject/main/models/Content.java
+++ b/contentManagement/src/main/java/com/audiophileproject/main/models/Content.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.net.URL;
 import java.util.Date;
 import java.util.List;
 
@@ -29,8 +30,9 @@ public class Content {
 	@NotNull
 	private String title;
 	@NotNull
-	private String url;
-	private String type;
+	@Column(columnDefinition = "TEXT")
+	private URL url;
+	private String contentType;
 	private Long length;
 	@Lob
 	private String description;


### PR DESCRIPTION
We are now not relaying on a external dependency for determining the content type and length, and we're also dropping that dependency